### PR TITLE
Doppelte Einträge in Verwendungszweck vermeiden.

### DIFF
--- a/src/de/willuhn/jameica/hbci/paypal/synchronize/PaypalSynchronizeJobKontoauszug.java
+++ b/src/de/willuhn/jameica/hbci/paypal/synchronize/PaypalSynchronizeJobKontoauszug.java
@@ -342,7 +342,15 @@ public class PaypalSynchronizeJobKontoauszug extends SynchronizeJobKontoauszug i
       for (CartItemDetail cd:t.cart_info.item_details)
       {
         if (StringUtils.trimToNull(cd.item_name) != null)
-          usages.add(cd.item_name);
+        {
+          if (!usages.isEmpty())
+          {
+            if (!usages.contains(cd.item_name))
+              usages.add(", " + cd.item_name);
+          }
+          else
+            usages.add(cd.item_name);
+        }
       }
     }
     
@@ -505,5 +513,5 @@ public class PaypalSynchronizeJobKontoauszug extends SynchronizeJobKontoauszug i
     Logger.info("startdate: " + HBCI.LONGDATEFORMAT.format(start));
     return start;
   }
-  
+
 }


### PR DESCRIPTION
- transaction_subject wird bei bestimmten Transaktionen auch als cart_info.item_detail mitgeliefert. In diesem Fall muss der Eintrag nicht wiederholt werden. https://github.com/willuhn/hibiscus.paypal/issues/7
- Füge bei vorhandenen Einträgen in Verwendungszweck ', ' als Trenner ein. https://github.com/willuhn/hibiscus.paypal/issues/8