### PR TITLE
Fix (true/false) Syntax

### DIFF
--- a/src/de/willuhn/jameica/hbci/paypal/Plugin.java
+++ b/src/de/willuhn/jameica/hbci/paypal/Plugin.java
@@ -36,7 +36,7 @@ public class Plugin extends AbstractPlugin
   /**
    * Meta-Parameter für Import-Auswahl
    */
-  public final static String META_PARAM_IMPORT_AUTHORIZATIONS = "Authorisierungsbuchungen importieren (true/false)";
+  public final static String META_PARAM_IMPORT_AUTHORIZATIONS = "Authorisierungsbuchungen importieren";
   
   /**
    * Liefert den Support-Status des Kontos.

--- a/src/de/willuhn/jameica/hbci/paypal/synchronize/PaypalSynchronizeBackend.java
+++ b/src/de/willuhn/jameica/hbci/paypal/synchronize/PaypalSynchronizeBackend.java
@@ -134,7 +134,7 @@ public class PaypalSynchronizeBackend extends AbstractSynchronizeBackend<PaypalS
     if (!Plugin.getStatus(konto).checkSyncProvider())
       return null;
     
-    return Arrays.asList(Plugin.META_PARAM_API_CLIENTID, Plugin.META_PARAM_API_SECRET, Plugin.META_PARAM_IMPORT_AUTHORIZATIONS);
+    return Arrays.asList(Plugin.META_PARAM_API_CLIENTID, Plugin.META_PARAM_API_SECRET, Plugin.META_PARAM_IMPORT_AUTHORIZATIONS+"(true/false)");
   }
 
   /**


### PR DESCRIPTION
Offenbar wird in der GUI das (true/false) abgeschnitten und dann auch abgeschnitten gespeichert, d.h. beim Lesen darf das Postfix nicht angehängt werden. Außerdem darf zwischen dem Label und dem (true/false) kein Leerzeichen sein (anscheinend passiert irgendwo auf tieferer Ebene ein trim).